### PR TITLE
Update erofs_tool.py

### DIFF
--- a/erofs_tool.py
+++ b/erofs_tool.py
@@ -227,7 +227,12 @@ class Erofs:
         self.fn = fn
         self.file_handle = open(fn, 'rb')
         self.file_size = os.fstat(self.file_handle.fileno()).st_size
-        self.mmap = mmap.mmap(self.file_handle.fileno(), 0, mmap.MAP_SHARED, mmap.PROT_READ)
+        if os.name == 'posix':  # Unix/Linux/MacOS
+            self.mmap = mmap.mmap(self.file_handle.fileno(), 0, mmap.MAP_SHARED, mmap.PROT_READ)
+        elif os.name == 'nt':  # Windows
+            self.mmap = mmap.mmap(self.file_handle.fileno(), 0, access=mmap.ACCESS_READ)
+        else:
+            raise OSError("Unsupported operating system")        
         self.super = struct_erofs_super.parse(self.mmap[0x400:0x400+struct_erofs_super.sizeof()])
         print("0x%08x-0x%08x: SUPER" % (0x400, 0x400 + struct_erofs_super.sizeof()))
         assert self.super.magic == 0xe0f5e1e2, "0x%x" % self.super.magic


### PR DESCRIPTION
### Cross-Platform Memory Mapping Compatibility

#### Problem:
The original implementation of memory-mapped files in the Erofs class used parameters specific to POSIX-compliant systems, causing compatibility issues on Windows. This resulted in an `AttributeError` because `mmap.MAP_SHARED` and `mmap.PROT_READ` are not available on Windows.

#### Solution:
Implemented a conditional check within the Erofs class constructor to determine the operating system at runtime. Based on the OS, it now selects the appropriate parameters for the `mmap.mmap()` function. This update ensures that the memory mapping functionality works seamlessly across Windows, Linux, and macOS.

#### Changes:
- Added an OS check in the `Erofs.__init__` method to use `mmap.MAP_SHARED` and `mmap.PROT_READ` on POSIX-compliant systems (Linux and macOS) and `mmap.ACCESS_READ` on Windows.
- Raised an `OSError` for any unsupported operating systems to prevent undefined behavior.

This update enhances the portability of the Erofs filesystem extractor tool, making it more robust and user-friendly across different development environments.