### PR TITLE
fix(deps): bump lxml and construct to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 certifi==2020.12.5
 cffi==1.14.3
 chardet==3.0.4
-construct==2.10.56
+construct==2.10.70
 crypto==1.4.1
 cryptography==3.2.1
 et-xmlfile==1.0.1
 idna==2.10
 jdcal==1.4.1
-lxml==5.2.2
+lxml==6.0.2
 Naked==0.1.31
 protobuf==3.15.1
 pycparser==2.22


### PR DESCRIPTION
Bumping lxml and construct version to support python 3.13 
Ref: https://github.com/srlabs/extractor/issues/14#issuecomment-3579364919